### PR TITLE
Add Cardinal Health to companies

### DIFF
--- a/companies/cardinal-health.md
+++ b/companies/cardinal-health.md
@@ -1,0 +1,16 @@
+---
+fortune_rank: 16
+name: Cardinal Health
+tags: ["fortune500", "healthcare"]
+blm_statements:
+  - url: https://www.linkedin.com/posts/cardinal-health_i-cant-breathe-george-floyds-death-activity-6672273993170530304-r9vw/
+    date_posted: 2020-05-29
+exec_team_url: https://www.cardinalhealth.com/en/about-us/our-people/our-leaders.html
+diversity_inclusion_url: https://www.cardinalhealth.com/en/about-us/our-people/diversity-and-inclusion.html
+---
+
+“I can’t breathe.”
+
+"George Floyd’s death should never have happened. Inhumanity against one is inhumanity against all. This has to stop. All of us have a responsibility to encourage unity and demand justice for George Floyd, Breonna Taylor and too many others whose lives have been cut short by racism throughout our country’s history. We must come together so that everyone enjoys the same privilege of living, working and raising their families in a community that is safe for all.” 
+
+-- Statement from Cardinal Health on the death of George Floyd and Columbus, Ohio, demonstrations


### PR DESCRIPTION
# Description

This pull request is for Issue https://github.com/DiversityCorp/companies-on-blm/issues/35. I am adding a document for Cardinal Health to the companies/ directory. This is part of hacktoberfest 2020. As mentioned in the issue, there doesn't seem to be any formal company statement posted. The closest thing was a statement the company posted on LinkedIn.

Fixes # https://github.com/DiversityCorp/companies-on-blm/issues/35

## Type of change

- [X] Company data addition

# How Has This Been Tested?

I started the server locally and verified the Cardinal Health page displays as expected on the Statements page and also that "see more" brings the user to the specific statement for Cardinal Health.

**Test Configuration**:
* Browser: Chrome

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
