### PR TITLE
move statement meme to homepage & add explanation

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -8,6 +8,22 @@ layout: layouts/base.njk
 		</div>
 </div>
 
+<div class="container why-container">
+		<h2>Why do we exist?</h2>
+		<div class="row why-img-text-container">
+			<div class="col-12 col-lg-6">
+					<img
+							src="https://pbs.twimg.com/media/EZXvqb6X0AEDkOI?format=jpg&name=medium"
+							class="meme-img"
+							alt="Meme of white text on black background that says: We at [Brand] are committed to fighting injustice by posting images to Twitter that express our commitment to fighting injustice. To that end, we offer this solemn white-on-black .jpeg that expresses vague solidarity with the Black community, but will quietly elide the specifics of what is wrong, what needs to change, or in what ways we will do anything about it. This is doubly true if [Brand] is particularly guilty of exacerbating these issues. We hope this action encourages you to view [Brand] positively without, you know, expecting anything from us. From, [Brand]&reg; You know the ones.&trade;"
+					/>
+			</div>
+			<div class="col-12 col-lg-6">
+				<p>Corporate America has largely ignored the issues of police brutality and systemic racism. After the murder of George Floyd, thousands of black &amp; white statements flooded social media, claiming that they are listening and will no longer be complicit. Some of these were specific, measurable, and actionable, and some of them were little more than a black box with a hashtag. We've gathered their initial responses and subsequent follow-ups so you can start sorting through which organizations are genuinely invested and interested in making a difference and which are not.</p>
+			</div>
+		</div>
+</div>
+
 <div style="color: #777;background-color:white;text-align:center;padding:50px 80px;text-align: justify;">
 		<div class="container homepage">
 				<div class="shadow-lg p-3 mb-5 bg-white rounded">

--- a/statements.njk
+++ b/statements.njk
@@ -5,11 +5,7 @@ layout: layouts/base.njk
 <div class="container">
     <img src="{{ '/images/logo.png' | url }}" alt="">
     <h2>We hold companies accountable.</h2>
-    <p>Below, we will display companies and their responses to the Black Lives Matter Movement.</p>
-    <div class="container">
-        <img src="https://pbs.twimg.com/media/EZXvqb6X0AEDkOI?format=jpg&name=medium" class="img-fluid" height="50%" alt="Responsive image">
-    </div>
-    <br/>
+    <p>View responses to the Black Lives Matter Movement.</p>
     <div class="container">
         <div class="row">
             {% include "tagslist.njk" %}

--- a/style.css
+++ b/style.css
@@ -146,8 +146,41 @@ a:active {
   text-decoration: none;
 }
 
-
 .resource-summary{
   text-align: left;
   color: black;
+}
+
+.why-container {
+  padding-top: 50px;
+  color: black;
+}
+
+.why-container h2 {
+  margin-bottom: 30px;
+}
+
+.why-img-text-container {
+  display: flex;
+  align-items: center;
+}
+
+.why-container img {
+  width: 100%;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.why-container p {
+  margin-bottom: 0;
+  margin-top: 30px;
+  padding: 28px 40px;
+  border-style: dotted;
+}
+
+@media (min-width: 992px) {
+  .why-container p {
+    margin-top: 0;
+  }
 }


### PR DESCRIPTION
# Description

Moved statement meme from "Statements" page to homepage. Add explanation for why this exists/is necessary.

Desktop:
<img width="800" alt="desktop" src="https://user-images.githubusercontent.com/20443660/100231865-96650480-2ef5-11eb-8ddf-58cd91f16330.png">

Mobile:
<img width="400" alt="mobile" src="https://user-images.githubusercontent.com/20443660/100231861-95cc6e00-2ef5-11eb-80f8-86946755aa9c.png">

Fixes #164 

## Type of change

- [x] Bug fix
- [x] New feature

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* Browser: Chrome 86.0.4240.111, Firefox 81.0.2, Safari 14.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
